### PR TITLE
Add lsp-ivy-show-symbol-kind and lsp-ivy-filter-symbol-kind options

### DIFF
--- a/lsp-ivy.el
+++ b/lsp-ivy.el
@@ -35,12 +35,13 @@
 (require 'ivy)
 (require 'dash)
 (require 'lsp-mode)
+
 (defgroup lsp-ivy nil
   "LSP support for ivy-based symbol completion"
   :group 'lsp-mode)
 
 (defcustom lsp-ivy-show-symbol-kind
-  nil
+  t
   "Whether to show the symbol's kind when showing lsp symbols"
   :group 'lsp-ivy
   :type 'boolean)
@@ -116,10 +117,12 @@
   (let* ((container-name (gethash "containerName" match))
          (name (gethash "name" match))
          (type (elt lsp-ivy-symbol-kind-to-string (gethash "kind" match) ))
-         (typestr (propertize (format "[%s]" (car type)) 'face `(:foreground ,(cdr type)))))
-    (if (or (null container-name) (string-empty-p container-name))
-        (format "%s %s" typestr name)
-      (format "%s %s.%s" typestr container-name name))))
+         (typestr (if lsp-ivy-show-symbol-kind
+                      (propertize (format "[%s] " (car type)) 'face `(:foreground ,(cdr type)))
+                    "")))
+    (concat typestr (if (or (null container-name) (string-empty-p container-name))
+                        (format "%s" name)
+                      (format "%s.%s" container-name name)))))
 
 (defun lsp-ivy--workspace-symbol-action (candidate)
   "Jump to selected CANDIDATE."

--- a/lsp-ivy.el
+++ b/lsp-ivy.el
@@ -18,10 +18,9 @@
 ;; Authors: Sebastian Sturm
 ;;          Oliver Rausch
 ;; Keywords: languages, debug
-;; Package-Version: 20191028.902
 ;; URL: https://github.com/emacs-lsp/lsp-ivy
 ;; Package-Requires: ((emacs "25.1") (dash "2.14.1") (lsp-mode "5.0") (ivy "0.13.0"))
-;; Version: 0.1
+;; Version: 0.2
 ;;
 
 ;;; Commentary:


### PR DESCRIPTION
These options show the type of a symbol in the ivy completion. I found these extensions useful for myself, feel free to merge them if you think it's a good fit for the package.

Here's a screenshot of the default configuration:
![image](https://user-images.githubusercontent.com/22137236/77010954-1d2b1000-696b-11ea-9396-17defaea796f.png)


