### PR TITLE
Fix out-of-bounds access (#19)

### DIFF
--- a/lsp-ivy.el
+++ b/lsp-ivy.el
@@ -137,7 +137,8 @@
   ((&SymbolInformation :name :kind :container-name? :location (&Location :uri))
    project-root)
   "Convert the match returned by `lsp-mode` into a candidate string."
-  (let* ((type (elt lsp-ivy-symbol-kind-to-face kind))
+  (let* ((sanitized-kind (if (< kind (length lsp-ivy-symbol-kind-to-face)) kind 0))
+         (type (elt lsp-ivy-symbol-kind-to-face sanitized-kind))
          (typestr (if lsp-ivy-show-symbol-kind
                       (propertize (format "[%s] " (car type)) 'face (cdr type))
                     ""))


### PR DESCRIPTION
at least one language server (ccls) uses symbol kinds greater than 26 that, using the default value of `lsp-ivy-symbol-kind-to-face`, will trigger out-of-bounds errors (see issue #19). This PR avoids the issue by remapping anything beyond `(length lsp-ivy-symbol-kind-to-face)` to entry 0 (unknown - empty label).

Personally, I've never seen this issue so perhaps it's rare and the few (?) users who have run into it have for the most part decided to just resize their `lsp-ivy-symbol-kind-to-face` accordingly and fill in the interesting slots. Or perhaps this is a common issue and `lsp-ivy-symbol-kind-to-face` should be changed to an associative container to more conveniently extend to discontinuous value ranges as used by ccls. Opinions welcome