### PR TITLE
Add a command to remove workspace folders

### DIFF
--- a/lsp-ivy.el
+++ b/lsp-ivy.el
@@ -220,5 +220,17 @@ When called with prefix ARG the default selection will be symbol at point."
    "Global workspace symbols: "
    (when arg (thing-at-point 'symbol))))
 
+
+;;;###autoload
+(defun lsp-ivy-workspace-folder-remove ()
+  "Remove a project-root from the list of workspace folders."
+  (interactive)
+  (let ((session (lsp-session)))
+    (ivy-read "Select workspace folder to remove: " (lsp-session-folders session)
+              :preselect (-some->> default-directory (lsp-find-session-folder session))
+              :action (lambda (x)
+                        (lsp-workspace-folders-remove x)
+                        (ivy--kill-current-candidate)))))
+
 (provide 'lsp-ivy)
 ;;; lsp-ivy.el ends here

--- a/lsp-ivy.el
+++ b/lsp-ivy.el
@@ -228,8 +228,8 @@ When called with prefix ARG the default selection will be symbol at point."
   (let ((session (lsp-session)))
     (ivy-read "Select workspace folder to remove: " (lsp-session-folders session)
               :preselect (-some->> default-directory (lsp-find-session-folder session))
-              :action (lambda (x)
-                        (lsp-workspace-folders-remove x)
+              :action (lambda (folder)
+                        (lsp-workspace-folders-remove folder)
                         (ivy--kill-current-candidate)))))
 
 (provide 'lsp-ivy)

--- a/lsp-ivy.el
+++ b/lsp-ivy.el
@@ -222,7 +222,7 @@ When called with prefix ARG the default selection will be symbol at point."
 
 
 ;;;###autoload
-(defun lsp-ivy-workspace-folder-remove ()
+(defun lsp-ivy-workspace-folders-remove ()
   "Remove a project-root from the list of workspace folders."
   (interactive)
   (let ((session (lsp-session)))

--- a/lsp-ivy.el
+++ b/lsp-ivy.el
@@ -221,6 +221,7 @@ When called with prefix ARG the default selection will be symbol at point."
    (when arg (thing-at-point 'symbol))))
 
 
+
 ;;;###autoload
 (defun lsp-ivy-workspace-folders-remove ()
   "Remove a project-root from the list of workspace folders."


### PR DESCRIPTION
Sometimes it is useful to remove a lot of workspace folders at once.
Calling `lsp-workspace-folders-remove` repeatedly is not very convenient though,
so wrap it in `ivy`, allowing the user to simply invoke `ivy-call`.

---

As a bonus, the ivy command doesn't break if `default-directory` is nil for some
reason, but I will be addressing this in upstream `lsp-mode` as well.

----

#