### PR TITLE
Add lsp-ivy-document-symbol

### DIFF
--- a/lsp-ivy.el
+++ b/lsp-ivy.el
@@ -243,8 +243,7 @@ and children nodes."
     (forward-char character)))
 
 (defun lsp-ivy-document-symbol ()
-  "`ivy' for lsp workspace/symbol.
-When called with prefix ARG the default selection will be symbol at point."
+  "`ivy' for lsp textDocument/documentSymbol."
   (interactive)
   (let* ((xs (lsp-request-while-no-input "textDocument/documentSymbol"
                                          (lsp--text-document-position-params)))


### PR DESCRIPTION
This adds an implementation of `lsp-ivy-document-symbol`; at some point I got frustrated with imenu and how it behaves (at least to what I have on doom emacs) and figured I might do something about this.

This might need more love, testing and feedback to get up to a good quality, but I already have support for both DocumentSymbol and SymbolInformation (older LSP servers) as response from `textDocument/documentSymbol`.

<img width="1572" alt="Bildschirmfoto 2022-09-30 um 22 07 33" src="https://user-images.githubusercontent.com/563556/193339932-5d7f8483-964a-4680-b2ba-b68cbb8c6136.png">
